### PR TITLE
Add min/max lat/lon to orbiter

### DIFF
--- a/examples/orbiter/index.js
+++ b/examples/orbiter/index.js
@@ -38,7 +38,14 @@ const camera = renderer.entity([
     near: 0.1,
     far: 100
   }),
-  renderer.orbiter({ element: ctx.gl.canvas, distance: 2 })
+  renderer.orbiter({
+    element: ctx.gl.canvas,
+    distance: 2,
+    minLat: -30,
+    maxLat: 30,
+    minLon: -90,
+    maxLon: 90
+  })
 ])
 renderer.add(camera)
 

--- a/orbiter.js
+++ b/orbiter.js
@@ -67,8 +67,8 @@ function Orbiter (opts) {
     currentDistance: 1,
     minDistance: 0.1,
     maxDistance: 10,
-    minLat: -90,
-    maxLat: 90,
+    minLat: -89.5,
+    maxLat: 89.5,
     minLon: -Infinity,
     maxLon: Infinity,
     zoomSlowdown: 400,
@@ -107,8 +107,8 @@ Orbiter.prototype.set = function (opts) {
     this.currentDistance = this.distance
     this.minDistance = opts.minDistance || distance / 10
     this.maxDistance = opts.maxDistance || distance * 10
-    this.minLat = opts.minLat || -90
-    this.maxLat = opts.maxLat || 90
+    this.minLat = opts.minLat || -89.5
+    this.maxLat = opts.maxLat || 89.5
     this.minLon = opts.minLon || -Infinity
     this.maxLon = opts.maxLon || Infinity
   }

--- a/orbiter.js
+++ b/orbiter.js
@@ -67,6 +67,10 @@ function Orbiter (opts) {
     currentDistance: 1,
     minDistance: 0.1,
     maxDistance: 10,
+    minLat: -90,
+    maxLat: 90,
+    minLon: -Infinity,
+    maxLon: Infinity,
     zoomSlowdown: 400,
     zoom: true,
     pan: true,
@@ -103,6 +107,10 @@ Orbiter.prototype.set = function (opts) {
     this.currentDistance = this.distance
     this.minDistance = opts.minDistance || distance / 10
     this.maxDistance = opts.maxDistance || distance * 10
+    this.minLat = opts.minLat || -90
+    this.maxLat = opts.maxLat || 90
+    this.minLon = opts.minLon || -Infinity
+    this.maxLon = opts.maxLon || Infinity
   }
   Object.keys(opts).forEach((prop) => this.changed.dispatch(prop))
 }
@@ -141,8 +149,8 @@ Orbiter.prototype.updateMatrix = function () {
   const position = this.position
   const target = this.target
 
-  this.lat = clamp(this.lat, -89.5, 89.5)
-  this.lon = this.lon % (360)
+  this.lat = clamp(this.lat, this.minLat, this.maxLat)
+  this.lon = clamp(this.lon, this.minLon, this.maxLon) % 360
 
   this.currentLat = toDegrees(
     interpolateAngle(


### PR DESCRIPTION
* Add ability to clamp lat (range -90 to 90) and lon (range Infinity)
* Using degrees as the rest is also using degrees
* Updated orbiter example

Issue in `set`:
`const latLon = xyzToLatLon(vec3.normalize(vec3.sub(vec3.copy(this.position), this.target)))`

`xyzToLatLon` returns an initial -90 as longitude. I would expect it to be 0 if the position is only moved on z axis (eg setting distance) but I might be missing something here?