### PR TITLE
Add shader precision handling with default setting and material specific override

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -148,12 +148,13 @@ Camera.prototype.set = function (opts) {
 }
 
 Camera.prototype.initPostproces = function () {
-  var ctx = this.ctx
-  var fsqPositions = [[-1, -1], [1, -1], [1, 1], [-1, 1]]
-  var fsqFaces = [[0, 1, 2], [0, 2, 3]]
+  const ctx = this.ctx
+  const precisionStr = `precision ${ctx.capabilities.maxPrecision} float;\n`
+  const fsqPositions = [[-1, -1], [1, -1], [1, 1], [-1, 1]]
+  const fsqFaces = [[0, 1, 2], [0, 2, 3]]
 
-  var W = this.viewport[2]
-  var H = this.viewport[3]
+  const W = this.viewport[2]
+  const H = this.viewport[3]
 
   this._fsqMesh = {
     attributes: {
@@ -268,8 +269,8 @@ Camera.prototype.initPostproces = function () {
       // clearDepth: 1
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: SAO_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + SAO_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -288,8 +289,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: BILATERAL_BLUR_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + BILATERAL_BLUR_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -311,8 +312,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: BILATERAL_BLUR_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + BILATERAL_BLUR_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -334,8 +335,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: BILATERAL_BLUR_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + BILATERAL_BLUR_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -355,8 +356,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: BILATERAL_BLUR_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + BILATERAL_BLUR_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -376,8 +377,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 1, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: THRESHOLD_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + THRESHOLD_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -398,8 +399,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 1, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: BLOOM_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + BLOOM_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -419,8 +420,8 @@ Camera.prototype.initPostproces = function () {
       clearColor: [1, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: BLOOM_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + BLOOM_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,
@@ -436,8 +437,8 @@ Camera.prototype.initPostproces = function () {
   this._blitCmd = {
     name: 'Camera.blit',
     pipeline: ctx.pipeline({
-      vert: POSTPROCESS_VERT,
-      frag: POSTPROCESS_FRAG
+      vert: precisionStr + POSTPROCESS_VERT,
+      frag: precisionStr + POSTPROCESS_FRAG
     }),
     attributes: this._fsqMesh.attributes,
     indices: this._fsqMesh.indices,

--- a/examples/postprocessing/index.js
+++ b/examples/postprocessing/index.js
@@ -18,7 +18,7 @@ dragon.positions = centerAndNormalize(dragon.positions).map((v) => vec3.scale(v,
 dragon.normals = normals(dragon.cells, dragon.positions)
 dragon.uvs = dragon.positions.map(() => [0, 0])
 const parseHdr = require('parse-hdr')
-const ctx = createContext()
+const ctx = createContext({ precision: 'mediump' })
 ctx.gl.getExtension('EXT_shader_texture_lod')
 ctx.gl.getExtension('OES_standard_derivatives')
 ctx.gl.getExtension('WEBGL_draw_buffers')

--- a/material.js
+++ b/material.js
@@ -36,6 +36,7 @@ function Material (opts) {
   this.blendSrcAlphaFactor = ctx.BlendFactor.One
   this.blendDstRGBFactor = ctx.BlendFactor.One
   this.blendDstAlphaFactor = ctx.BlendFactor.One
+  this.precision = opts.precision ? ctx.getMaxPrecision(opts.precision) : null
   this.castShadows = false
   this.receiveShadows = false
   this.cullFace = true

--- a/reflection-probe.js
+++ b/reflection-probe.js
@@ -21,6 +21,7 @@ function ReflectionProbe (opts) {
   this._ctx = ctx
   this.dirty = true
 
+  const precisionStr = `precision ${ctx.capabilities.maxPrecision} float;\n`
   const CUBEMAP_SIZE = 512
   const dynamicCubemap = this._dynamicCubemap = ctx.textureCube({
     width: CUBEMAP_SIZE,
@@ -85,8 +86,8 @@ function ReflectionProbe (opts) {
       color: [ octMap ]
     }),
     pipeline: ctx.pipeline({
-      vert: FULLSCREEN_QUAD,
-      frag: CUBEMAP_TO_OCTMAP
+      vert: precisionStr + FULLSCREEN_QUAD,
+      frag: precisionStr + CUBEMAP_TO_OCTMAP
     }),
     attributes: attributes,
     indices: indices,
@@ -103,8 +104,8 @@ function ReflectionProbe (opts) {
       color: [ octMap ]
     }),
     pipeline: ctx.pipeline({
-      vert: FULLSCREEN_QUAD,
-      frag: CONVOLVE_OCT_MAP_ATLAS_TO_OCT_MAP
+      vert: precisionStr + FULLSCREEN_QUAD,
+      frag: precisionStr + CONVOLVE_OCT_MAP_ATLAS_TO_OCT_MAP
     }),
     attributes: attributes,
     indices: indices,
@@ -133,8 +134,8 @@ function ReflectionProbe (opts) {
       color: [ octMapAtlas ]
     }),
     pipeline: ctx.pipeline({
-      vert: FULLSCREEN_QUAD,
-      frag: BLIT_TO_OCT_MAP_ATLAS
+      vert: precisionStr + FULLSCREEN_QUAD,
+      frag: precisionStr + BLIT_TO_OCT_MAP_ATLAS
     }),
     uniforms: {
       uSource: octMap,
@@ -152,8 +153,8 @@ function ReflectionProbe (opts) {
       clearColor: [0, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: FULLSCREEN_QUAD,
-      frag: DOWNSAMPLE_FROM_OCT_MAP_ATLAS
+      vert: precisionStr + FULLSCREEN_QUAD,
+      frag: precisionStr + DOWNSAMPLE_FROM_OCT_MAP_ATLAS
     }),
     uniforms: {
       uSource: octMapAtlas,
@@ -171,8 +172,8 @@ function ReflectionProbe (opts) {
       clearColor: [0, 1, 0, 1]
     }),
     pipeline: ctx.pipeline({
-      vert: FULLSCREEN_QUAD,
-      frag: PREFILTER_FROM_OCT_MAP_ATLAS
+      vert: precisionStr + FULLSCREEN_QUAD,
+      frag: precisionStr + PREFILTER_FROM_OCT_MAP_ATLAS
     }),
     uniforms: {
       uSource: octMapAtlas,

--- a/shaders/error/error.frag.js
+++ b/shaders/error/error.frag.js
@@ -1,6 +1,4 @@
 module.exports = /* glsl */`
-precision mediump float;
-
 void main () {
   gl_FragData[0] = vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/shaders/pipeline/depth-pass.frag.js
+++ b/shaders/pipeline/depth-pass.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 // Variables
 varying vec3 vNormalView;
 varying vec2 vTexCoord0;

--- a/shaders/pipeline/depth-pre-pass.frag.js
+++ b/shaders/pipeline/depth-pre-pass.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 // Variables
 varying vec3 vNormalView;
 varying vec2 vTexCoord0;

--- a/shaders/pipeline/material.frag.js
+++ b/shaders/pipeline/material.frag.js
@@ -6,13 +6,11 @@ module.exports = /* glsl */`
   #extension GL_EXT_draw_buffers : enable
 #endif
 
-precision mediump float;
-
 // Variables
-uniform highp mat4 uInverseViewMatrix;
-uniform highp mat4 uViewMatrix;
-uniform highp mat3 uNormalMatrix;
-uniform highp mat4 uModelMatrix;
+uniform mat4 uInverseViewMatrix;
+uniform mat4 uViewMatrix;
+uniform mat3 uNormalMatrix;
+uniform mat4 uModelMatrix;
 
 uniform vec3 uCameraPosition;
 

--- a/shaders/pipeline/overlay.frag.js
+++ b/shaders/pipeline/overlay.frag.js
@@ -1,6 +1,4 @@
 module.exports = /* glsl */`
-precision highp float;
-
 varying vec2 vTexCoord;
 uniform sampler2D uTexture;
 void main() {

--- a/shaders/post-processing/bilateral-blur.frag.js
+++ b/shaders/post-processing/bilateral-blur.frag.js
@@ -1,6 +1,4 @@
 module.exports = /* glsl */`
-precision highp float;
-
 varying vec2 vTexCoord;
 
 uniform float near;

--- a/shaders/post-processing/bloom.frag.js
+++ b/shaders/post-processing/bloom.frag.js
@@ -1,6 +1,4 @@
 module.exports = /* glsl */`
-precision highp float;
-
 varying vec2 vTexCoord;
 
 uniform float near;

--- a/shaders/post-processing/post-processing.frag.js
+++ b/shaders/post-processing/post-processing.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 // Variables
 uniform vec2 uScreenSize;
 

--- a/shaders/post-processing/sao.frag.js
+++ b/shaders/post-processing/sao.frag.js
@@ -3,8 +3,6 @@ module.exports = /* glsl */`
 // Updated by marcin.ignac@gmail.com 2017-05-08
 #extension GL_OES_standard_derivatives : enable
 
-precision mediump float;
-
 // total number of samples at each fragment
 #define NUM_SAMPLES 11
 

--- a/shaders/post-processing/threshold.frag.js
+++ b/shaders/post-processing/threshold.frag.js
@@ -1,6 +1,4 @@
 module.exports = /* glsl */`
-precision highp float;
-
 varying vec2 vTexCoord;
 
 uniform float near;

--- a/shaders/reflection-probe/blit-to-oct-map-atlas.frag.js
+++ b/shaders/reflection-probe/blit-to-oct-map-atlas.frag.js
@@ -1,6 +1,4 @@
 module.exports = /* glsl */`
-precision highp float;
-
 varying vec2 vTexCoord;
 
 uniform float uLevelSize;

--- a/shaders/reflection-probe/convolve-oct-map-atlas-to-oct-map.frag.js
+++ b/shaders/reflection-probe/convolve-oct-map-atlas-to-oct-map.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 ${SHADERS.octMapUvToDir}
 ${SHADERS.octMap}
 ${SHADERS.rgbm}

--- a/shaders/reflection-probe/cubemap-to-octmap.frag.js
+++ b/shaders/reflection-probe/cubemap-to-octmap.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 ${SHADERS.octMapUvToDir}
 
 varying vec2 vTexCoord;

--- a/shaders/reflection-probe/downsample-from-oct-map-atlas.frag.js
+++ b/shaders/reflection-probe/downsample-from-oct-map-atlas.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 ${SHADERS.octMapUvToDir}
 ${SHADERS.octMap}
 

--- a/shaders/reflection-probe/prefilter-from-oct-map-atlas.frag.js
+++ b/shaders/reflection-probe/prefilter-from-oct-map-atlas.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 // Variables
 varying vec2 vTexCoord;
 uniform float uTextureSize;

--- a/shaders/skybox/sky-env-map.frag.js
+++ b/shaders/skybox/sky-env-map.frag.js
@@ -1,8 +1,6 @@
 const SHADERS = require('../chunks/index.js')
 
 module.exports = /* glsl */`
-precision highp float;
-
 ${SHADERS.math.PI}
 ${SHADERS.sky}
 ${SHADERS.rgbm}

--- a/shaders/skybox/sky-env-map.vert.js
+++ b/shaders/skybox/sky-env-map.vert.js
@@ -1,4 +1,4 @@
-module.exports = `
+module.exports = /* glsl */`
 attribute vec3 aPosition;
 attribute vec2 aTexCoord0;
 

--- a/shaders/skybox/skybox.frag.js
+++ b/shaders/skybox/skybox.frag.js
@@ -5,8 +5,6 @@ module.exports = /* glsl */`
   #extension GL_EXT_draw_buffers : enable
 #endif
 
-precision highp float;
-
 #define USE_TONEMAPPING
 
 // Variables

--- a/skybox.js
+++ b/skybox.js
@@ -22,14 +22,15 @@ function Skybox (opts) {
 
   this.set(opts)
 
+  const precisionStr = `precision ${ctx.capabilities.maxPrecision} float;\n`
   const skyboxPositions = [[-1, -1], [1, -1], [1, 1], [-1, 1]]
   const skyboxFaces = [[0, 1, 2], [0, 2, 3]]
 
   this._drawCommand = {
     name: 'Skybox.draw',
     pipeline: ctx.pipeline({
-      vert: SKYBOX_VERT,
-      frag: SKYBOX_FRAG,
+      vert: precisionStr + SKYBOX_VERT,
+      frag: precisionStr + SKYBOX_FRAG,
       depthTest: true
     }),
     attributes: {
@@ -61,8 +62,8 @@ function Skybox (opts) {
       clearColor: [0, 0, 0, 0]
     }),
     pipeline: ctx.pipeline({
-      vert: SKYTEXTURE_VERT,
-      frag: SKYTEXTURE_FRAG
+      vert: precisionStr + SKYTEXTURE_VERT,
+      frag: precisionStr + SKYTEXTURE_FRAG
     }),
     uniforms: {
       uSunPosition: [0, 0, 0]


### PR DESCRIPTION
- Parameter override on state creation. Allows the use of a lower precision than the max available if set otherwise default to pex-context maxPrecision: `this.precision = opts.precision ? ctx.getMaxPrecision(State.precision) : ctx.capabilities.maxPrecision`
- Automatic precision handling from context in Camera, ReflectionProbe and Skybox
- Material caching updated to precision precision on top of flags, vert and frag
- Removed precision strings in all shaders as it is now set on `getMaterialProgram` or in Camera, ReflectionProbe and Skybox components

Dependent on https://github.com/pex-gl/pex-context/pull/60