### PR TITLE
feat(ecs): update bounds computation in geometry system

### DIFF
--- a/systems/morph.js
+++ b/systems/morph.js
@@ -1,5 +1,3 @@
-import { aabb } from "pex-geom";
-
 function updateMorph(morph) {
   Object.keys(morph.sources).forEach((key) => {
     const sourceAttributes = morph.sources[key];
@@ -49,14 +47,9 @@ export default () => ({
 
       Object.keys(entity.morph.current).forEach((key) => {
         entity.geometry[key] = entity.morph.current[key];
+        // Bounds will be recomputed in geometry system update if "positions"/"offsets" are dirty
         entity.geometry[key].dirty = true;
       });
-
-      // TODO: should that be in geometry system as geometry.bounds.dirty or aabbDirty?
-      entity.geometry.bounds = aabb.fromPoints(
-        entity.geometry.bounds || aabb.create(),
-        entity.morph.current.positions || entity.morph.current.offsets,
-      );
     }
   },
 });


### PR DESCRIPTION
- compute bounds for instanced geometries
- don't overwrite bounds if previously set and positions/offsets are ArrayBuffer (use case: glTF)
- always recompute bounds on positions/offsets change (should there be a frozen state as an optimisation?)
- remove useless bounds computation in morph system (happens in geometry system if morph changes positions/offsets)
- skin system bbox update not implemented: can't handle it without computing skin matrix CPU side